### PR TITLE
Add Token dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,23 @@ export default (state, action) => {
 
 ### API
 
-The following events are emitted:
+#### Dependency registration
+
+```js
+import UniversalEvents, {UniversalEventsToken} from 'fusion-plugin-universal-events';
+
+app.register(UniversalEventsToken, UniversalEvents);
+```
+
+#### Required dependencies
+
+Name | Type | Description
+-|-|-
+`UniversalEventsToken` | `UniversalEvents` | An event emitter plugin, such as the one provided by [`fusion-plugin-universal-events`](https://github.com/fusionjs/fusion-plugin-universal-events).
+
+#### Instance API
+
+To consume action events, add an event listener for the following emitted events:
 
 - `redux-action-emitter:action`
 


### PR DESCRIPTION
Fixes #43 | Rendered: [link](https://github.com/AlexMSmithCA/fusion-redux-action-emitter-enhancer/blob/c79a0114b1d216b7b12d7a1b3ff633382cbfcbd2/README.md)

> #### Problem/Rationale
> 
> Documentation regarding Fusion API is out of date given recent changes to leverage new Dependency Injection architecture. 
> 
> #### Solution/Change/Deliverable
> 
> Update documentation