### PR TITLE
Fix .flowconfig to not overwrite

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,14 +1,15 @@
 [ignore]
 .*/node_modules/.*[^(package)]\.json$
+<PROJECT_ROOT>/dist/.*
 
 [include]
 ./src/
 
 [libs]
+./node_modules/fusion-core/flow-typed
 
 [lints]
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore
 
 [strict]


### PR DESCRIPTION
**Problem**

`.flowconfig` in a some repositories still override `$FlowFixMe` which causes release verification failures ([example](https://buildkite.com/uberopensource/fusion-release-verification/builds/268#f49f188d-63db-4a7f-a9ef-b8e228b16fdf)).

**Solution**

Identify and update the `.flowconfig` files for all of these offending repositories.
