### PR TITLE
Add transformer to payloads (ActionEmitterTransformerToken)

### DIFF
--- a/docs/migrations/00115.md
+++ b/docs/migrations/00115.md
@@ -1,0 +1,1 @@
+If you were consuming properties on the raw `action` payload other than the default(`{type, _trackingMeta}`), add a transformer for you payloads. See README section ["Transforming action payloads on emission"](https://github.com/fusionjs/fusion-plugin-redux-action-emitter-enhancer#transforming-action-payloads-on-emission)

--- a/src/__tests__/app.node.js
+++ b/src/__tests__/app.node.js
@@ -62,7 +62,7 @@ test('plugin - service resolved as expected', t => {
         };
         const mockReducer: Reducer<*, *> = s => s;
         const enhanced = enhancer(createStore)(mockReducer);
-        enhanced.dispatch();
+        enhanced.dispatch({});
         wasResolved = true;
       },
     })

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -14,7 +14,7 @@ import {UniversalEventsToken} from 'fusion-plugin-universal-events';
 import type {Context} from 'fusion-core';
 import {getService} from 'fusion-test-utils';
 
-import actionEmitterPlugin from '../index.js';
+import actionEmitterPlugin, {ActionEmitterTransformerToken} from '../index.js';
 
 type ExtractReturnType = <V>(() => V) => V;
 type IEmitter = $Call<typeof UniversalEventsToken, ExtractReturnType>;
@@ -52,10 +52,15 @@ const sampleReducer = (state = [], action) => {
   }
 };
 
-const appCreator = (emitter?: IEmitter) => {
+const appCreator = (deps?: {emitter?: IEmitter, transformer?: Function}) => {
+  const {emitter, transformer} = deps || {};
+
   const app = new App('test', el => el);
   if (emitter) {
     app.register(UniversalEventsToken, emitter);
+  }
+  if (transformer) {
+    app.register(ActionEmitterTransformerToken, transformer);
   }
   return () => app;
 };
@@ -67,7 +72,8 @@ test('Instantiation', t => {
     'requires the EventEmitter dependency'
   );
   t.doesNotThrow(
-    () => getService(appCreator(mockEventEmitter), actionEmitterPlugin),
+    () =>
+      getService(appCreator({emitter: mockEventEmitter}), actionEmitterPlugin),
     'provide the EventEmitter dependency'
   );
   t.end();
@@ -77,7 +83,7 @@ test('Emits actions', t => {
   // Setup
   const mockEventEmitter = getMockEventEmitterFactory();
   const enhancer = getService(
-    appCreator(mockEventEmitter),
+    appCreator({emitter: mockEventEmitter}),
     actionEmitterPlugin
   );
   const mockCtx = {mock: true};
@@ -105,14 +111,60 @@ test('Emits actions', t => {
         'SAMPLE_SET',
         'payload type is SAMPLE_SET, as expected'
       );
-      t.equal(payload.value, true, 'payload value is true, as expected');
+      t.ok(
+        typeof payload.foo === 'undefined',
+        'By default properties other than {type, _trackingMeta} is emitted'
+      );
       t.equal(ctx, mockCtxTyped, 'ctx was provided');
     });
   store.dispatch({
     type: 'SAMPLE_SET',
-    value: true,
+    foo: {bar: 1},
   });
 
   t.plan(3);
+  t.end();
+});
+
+test('transformers', t => {
+  // Setup
+  const mockEventEmitter = getMockEventEmitterFactory();
+
+  const enhancer = getService(
+    appCreator({
+      emitter: mockEventEmitter,
+      transformer: action => ({foo: action.foo}),
+    }),
+    actionEmitterPlugin
+  );
+  const mockCtx = {mock: true};
+  const mockCtxTyped = ((mockCtx: any): Context);
+  const store = createStore(
+    sampleReducer,
+    [],
+    compose(
+      enhancer,
+      createStore => (...args) => {
+        const store = createStore(...args);
+        // $FlowFixMe
+        store.ctx = mockCtx;
+        return store;
+      }
+    )
+  );
+
+  // Test Emits
+  mockEventEmitter
+    .from(mockCtxTyped)
+    .on('redux-action-emitter:action', (payload, ctx) => {
+      t.deepEqual(payload, {foo: 1}, 'payload is transformed');
+      t.equal(ctx, mockCtxTyped, 'ctx was provided');
+    });
+  store.dispatch({
+    type: 'SAMPLE_SET',
+    foo: 1,
+  });
+
+  t.plan(2);
   t.end();
 });


### PR DESCRIPTION
Introduces `ActionEmitterTransformerToken` to add transformer to raw action payloads before  emission. This is useful/required to ensure only necessary data are sent over-the-wire.