### PR TITLE
Handle non object actions

### DIFF
--- a/src/__tests__/app.node.js
+++ b/src/__tests__/app.node.js
@@ -62,7 +62,11 @@ test('plugin - service resolved as expected', t => {
         };
         const mockReducer: Reducer<*, *> = s => s;
         const enhanced = enhancer(createStore)(mockReducer);
-        enhanced.dispatch({});
+        enhanced.dispatch({
+          type: 'TEST',
+        });
+        enhanced.dispatch(function test() {});
+        enhanced.dispatch();
         wasResolved = true;
       },
     })
@@ -70,5 +74,6 @@ test('plugin - service resolved as expected', t => {
 
   t.true(wasResolved, 'test plugin was resolved');
   t.equal(eventsEmitted[0].type, 'redux-action-emitter:action');
+  t.equal(eventsEmitted.length, 1, 'only emits events for standard actions');
   t.end();
 });

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -91,15 +91,12 @@ test('Emits actions', t => {
   const store = createStore(
     sampleReducer,
     [],
-    compose(
-      enhancer,
-      createStore => (...args) => {
-        const store = createStore(...args);
-        // $FlowFixMe
-        store.ctx = mockCtx;
-        return store;
-      }
-    )
+    compose(enhancer, createStore => (...args) => {
+      const store = createStore(...args);
+      // $FlowFixMe
+      store.ctx = mockCtx;
+      return store;
+    })
   );
 
   // Test Emits
@@ -142,15 +139,12 @@ test('transformers', t => {
   const store = createStore(
     sampleReducer,
     [],
-    compose(
-      enhancer,
-      createStore => (...args) => {
-        const store = createStore(...args);
-        // $FlowFixMe
-        store.ctx = mockCtx;
-        return store;
-      }
-    )
+    compose(enhancer, createStore => (...args) => {
+      const store = createStore(...args);
+      // $FlowFixMe
+      store.ctx = mockCtx;
+      return store;
+    })
   );
 
   // Test Emits

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -91,12 +91,15 @@ test('Emits actions', t => {
   const store = createStore(
     sampleReducer,
     [],
-    compose(enhancer, createStore => (...args) => {
-      const store = createStore(...args);
-      // $FlowFixMe
-      store.ctx = mockCtx;
-      return store;
-    })
+    compose(
+      enhancer,
+      createStore => (...args) => {
+        const store = createStore(...args);
+        // $FlowFixMe
+        store.ctx = mockCtx;
+        return store;
+      }
+    )
   );
 
   // Test Emits
@@ -139,12 +142,15 @@ test('transformers', t => {
   const store = createStore(
     sampleReducer,
     [],
-    compose(enhancer, createStore => (...args) => {
-      const store = createStore(...args);
-      // $FlowFixMe
-      store.ctx = mockCtx;
-      return store;
-    })
+    compose(
+      enhancer,
+      createStore => (...args) => {
+        const store = createStore(...args);
+        // $FlowFixMe
+        store.ctx = mockCtx;
+        return store;
+      }
+    )
   );
 
   // Test Emits

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const plugin = createPlugin({
   },
   provides({
     emitter,
-    transformer,
+    transformer = defaultTransformer,
   }: {
     emitter: IEmitter,
     transformer?: Function,
@@ -48,15 +48,14 @@ const plugin = createPlugin({
       const store: Store<*, *, *> = createStore(...args);
       return {
         ...store,
-        dispatch: (action: Object) => {
-          let payload: Object = !transformer
-            ? defaultTransformer(action)
-            : transformer(action);
-
-          if (payload) {
-            emitter // $FlowFixMe
-              .from(store.ctx)
-              .emit('redux-action-emitter:action', payload);
+        dispatch: (action: mixed) => {
+          if (action && typeof action.type === 'string') {
+            let payload: Object = transformer(action);
+            if (payload) {
+              emitter // $FlowFixMe
+                .from(store.ctx)
+                .emit('redux-action-emitter:action', payload);
+            }
           }
 
           return store.dispatch(action);


### PR DESCRIPTION
Depending on various redux enhancements such as redux-thunk and redux-sagas,
actions with various types can be dispatched. We should only log standard actions